### PR TITLE
Memory fixes

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -127,13 +127,13 @@ block:
     if($5)
       token_append(tokholder, $5);
     $$ = tokholder->next;
-    free(tokholder);
+    tfree(tokholder);
   }
 ;
 labeldeclarationpart:
   LABEL addlabel SEMICOLON {
-    free($1);
-    free($3);
+    tfree($1);
+    tfree($3);
     $$ = $2;
   }
 | {$$ = NULL;}
@@ -146,7 +146,7 @@ addlabel:
   }
 | addlabel COMMA label {
     parse_label($3); 
-    free($2);
+    tfree($2);
     token_append($1, $3);
     $$ = $1;
   }
@@ -154,7 +154,7 @@ addlabel:
 
 constantdefinitionpart:
   CONST constantdefinition {
-    free($1);
+    tfree($1);
     $$ = $2;
   }
 | {$$ = NULL;}
@@ -163,15 +163,15 @@ constantdefinitionpart:
 constantdefinition:
   ID EQ constant SEMICOLON {
     parse_constantdefinition($1, $3);
-    free($2);
-    free($4);
+    tfree($2);
+    tfree($4);
     $1->leaf = $3;
     $$ = $1;
   }
 | constantdefinition ID EQ constant SEMICOLON {
     parse_constantdefinition($2, $4);
-    free($3);
-    free($5);
+    tfree($3);
+    tfree($5);
     token_append($1, $2);
     $$ = $1;
   }
@@ -196,7 +196,7 @@ constantid:
 
 typedefinitionpart:
   TYPE typedefinition {
-    free($1);
+    tfree($1);
     $$ = NULL;
   }
 | {$$ = NULL;}
@@ -205,14 +205,14 @@ typedefinitionpart:
 typedefinition:
   ID EQ typedenoter SEMICOLON {
     parse_typedefinition($1, $3);
-    free($2);
-    free($4);
+    tfree($2);
+    tfree($4);
     $$ = NULL;
   }
 | typedefinition ID EQ typedenoter SEMICOLON {
     parse_typedefinition($2, $4);
-    free($3);
-    free($5);
+    tfree($3);
+    tfree($5);
     $$ = NULL;
   }
 ;
@@ -269,8 +269,8 @@ realtypeid:
 
 enumeratedtype:
   LPAREN idlist RPAREN{
-    free($1);
-    free($3);
+    tfree($1);
+    tfree($3);
     $$ = parse_enumeratedtype($2);
   }
 ;
@@ -279,7 +279,7 @@ idlist:
   ID
 | idlist COMMA ID {
     token_append($1, $3);
-    free($2);
+    tfree($2);
     $$ = $1;
   }
 ;
@@ -307,10 +307,10 @@ unpackedstructuredtype:
 
 arraytype:
   ARRAY LBRACKET indextype RBRACKET OF componenttype {
-    free($1);
-    free($2);
-    free($4);
-    free($5);
+    tfree($1);
+    tfree($2);
+    tfree($4);
+    tfree($5);
     $$ = parse_arraytype($3, $6);
   }
 ;
@@ -318,7 +318,7 @@ arraytype:
 indextype:
   ordinaltype
 | indextype COMMA ordinaltype {
-    free($2);
+    tfree($2);
     token index = $1;
     token end = NULL;
     while(index){
@@ -336,31 +336,31 @@ componenttype:
 
 recordtype:
   RECORD fieldlist END {
-    free($1);
-    free($1);
+    tfree($1);
+    tfree($1);
     $$ = $2;
   }
 ;
 
 fieldlist:
   fixedpart SEMICOLON variantpart SEMICOLON {
-    free($2);
-    free($4);
+    tfree($2);
+    tfree($4);
     $$ = parse_fieldlist($1, $3);
   }
 | fixedpart SEMICOLON variantpart {
-    free($2);
+    tfree($2);
     $$ = parse_fieldlist($1, $3);
   }
 | fixedpart SEMICOLON {
-    free($2);
+    tfree($2);
     $$ = parse_fieldlist($1, NULL);
   }
 | fixedpart {
     $$ = parse_fieldlist($1, NULL);
   }
 | variantpart SEMICOLON {
-    free($2);
+    tfree($2);
     $$ = parse_fieldlist(NULL, $1);
   }
 | variantpart {
@@ -372,7 +372,7 @@ fieldlist:
 fixedpart:
   recordsection
 | recordsection SEMICOLON recordsection {
-    free($2);
+    tfree($2);
     token_append($1, $3);
     $$ = $1; 
   }
@@ -380,7 +380,7 @@ fixedpart:
 
 recordsection:
   idlist COLON typedenoter {
-    free($2);
+    tfree($2);
     $$ = parse_recordsection($1, $3);
   }
 ;
@@ -391,8 +391,8 @@ fieldid:
 
 variantpart:
   CASE variantselector OF variantext {
-    free($1);
-    free($3);
+    tfree($1);
+    tfree($3);
     $2->leaf = $4;
     $$ = $2;
   }
@@ -401,7 +401,7 @@ variantpart:
 variantext:
   variant
 | variantext SEMICOLON variant {
-    free($2);
+    tfree($2);
     token index = $1;
     token end = NULL;
     while(index){
@@ -415,9 +415,9 @@ variantext:
 
 variantselector:
   tagfield COLON tagtype {
-    free($2);
+    tfree($2);
     $1->type_sym = $3->entry;
-    free($3);
+    tfree($3);
     $$ = $1;
   }
 ;
@@ -428,9 +428,9 @@ tagfield:
 
 variant:
   caseconstantlist COLON LPAREN fieldlist RPAREN {
-    free($2);
-    free($3);
-    free($5);
+    tfree($2);
+    tfree($3);
+    tfree($5);
     $1->leaf = $4;
     $$ = $1;
   }
@@ -443,7 +443,7 @@ tagtype:
 caseconstantlist:
   caseconstant
 | caseconstantlist COMMA caseconstant {
-    free($2);
+    tfree($2);
     token index = $1;
     token end = NULL;
     while(index){
@@ -461,7 +461,7 @@ caseconstant:
 
 settype:
   SET OF basetype{
-    free($1);
+    tfree($1);
     $$ = parse_settype($3, $2);
   }
 ;
@@ -472,8 +472,8 @@ basetype:
 
 filetype:
   PASFILE OF componenttype {
-    free($1);
-    free($2);
+    tfree($1);
+    tfree($2);
     $$ = $3;
   }
 ;
@@ -489,7 +489,7 @@ pointertype:
 
 newpointertype:
   POINT domaintype {
-    free($1);
+    tfree($1);
     $$ = $2;
   }
 ;
@@ -807,8 +807,8 @@ statementsequence:
 compoundstatement:
   PASBEGIN END {
     $$ = NULL;
-    free($1);
-    free($2);
+    tfree($1);
+    tfree($2);
   }
 ;
 /*
@@ -946,8 +946,8 @@ program:
     //printf("%p\n", $3);
     //debugtokentree($3);
     $1->leaf = $3;
-    free($2);
-    free($4);
+    tfree($2);
+    tfree($4);
     parsetree = $1;
   }
 ;
@@ -958,8 +958,8 @@ programheading:
   }
 | PROG ID LPAREN programparameterlist RPAREN {
     $$ = parse_programheading($1, $2, $4);
-    free($3);
-    free($5);
+    tfree($3);
+    tfree($5);
   }
 ;
 
@@ -991,7 +991,7 @@ token parse_enumeratedtype(token idlist){
     entry->intval = i;
     symtab_add(top_symtab, entry);
     token temp = idlist->next;
-    free(idlist);
+    tfree(idlist);
     idlist = temp;
   }
   token retval = talloc();
@@ -1009,13 +1009,13 @@ token parse_subrangetype(token filltok, token lowbound, token highbound){
   entry->size = highbound->intval - lowbound->intval;
   cleartok(filltok);
   filltok->entry = entry;
-  free(lowbound);
-  free(highbound);
+  tfree(lowbound);
+  tfree(highbound);
   return filltok;
 }
 
 token parse_newstructuredtype(token typetok, token packed){
-  free(packed);
+  tfree(packed);
   return typetok;
 }
 
@@ -1065,7 +1065,7 @@ token parse_recordsection(token idlist, token typedenoter){
     arglistend->size = typedenoter->entry->size;
     arglistend->type = typedenoter->entry;
     token tmp = idlist->next;
-    free(idlist);
+    tfree(idlist);
     idlist = tmp;
   }
   cleartok(typedenoter);
@@ -1107,7 +1107,7 @@ token parse_constant(token sign, token constant){
     constant->realval *= -1;
     constant->entry = NULL;
   }
-  free(sign);
+  tfree(sign);
   return constant;
 }
 

--- a/src/symtab.c
+++ b/src/symtab.c
@@ -4,25 +4,16 @@
 #include <string.h>
 
 symtab symtab_alloc(void){
-  symtab retval = malloc(sizeof(symboltable));
-  retval->entrylist = NULL;
-  retval->prev = NULL;
+  symtab retval = calloc(1, sizeof(symboltable));
   return retval;
 }
 
 symentry symentry_alloc(void){
-  symentry retval = malloc(sizeof(tableentry));
-  retval->name = NULL;
-  retval->etype = INVALID_ENTRY;
+  symentry retval = calloc(1, sizeof(tableentry));
   retval->size = -1;
   retval->offset = -1;
-  retval->intval = 0;
-  retval->realval = 0.0;
-  retval->strval = NULL;
   retval->low = -1;
   retval->high = -1;
-  retval->type = NULL;
-  retval->next = NULL;
   return retval;
 }
 
@@ -36,6 +27,7 @@ symtab symtab_push(symtab parent){
 symtab symtab_pop(symtab child){
   printf("symtab pop\n");
   symtab parent = child->prev;
+  //TODO: symbol entries of child are probably leaking
   free(child);
   return parent;
 }

--- a/src/symtab.h
+++ b/src/symtab.h
@@ -20,7 +20,7 @@
 #define BLAISE_AVR_SYMTAB_H
 
 typedef enum entrytype{
-  INVALID_ENTRY,
+  INVALID_ENTRY = 0,
   LABEL_ENTRY,
   ID_ENTRY,
   CONST_ENTRY,

--- a/src/token.c
+++ b/src/token.c
@@ -35,9 +35,8 @@ token inittok(toktype type, int specval, int intval, double realval, char* strva
   t->specval = specval;
   t->intval = intval;
   t->realval = realval;
-  size_t strsize = strlen(strval);
-  t->strval = malloc(strsize * sizeof(char));
-  strncpy(t->strval, strval, strsize);
+  t->strval = malloc(strlen(strval) + 1);
+  strcpy(t->strval, strval);
   return t;
 }
 
@@ -102,8 +101,8 @@ void debugtoken(token tok){
   };
   union debugunion dbu;
   dbu.input = tok->realval;
-  printf("\n-----DEBUG TOKEN-----\n");
-  printf("Address: %p\n", tok);
+  printf("\n--------DEBUG TOKEN--------\n");
+  printf("%12s%p\n", "Address: ", tok);
   if(!tok ||
       tok->specval < PLUS ||
       tok->specval > STR ||
@@ -112,17 +111,17 @@ void debugtoken(token tok){
     printf("INVALID\n");
   }
   else{
-    printf("Type: %x\n", tok->type);
-    printf("specval: %s(%d)\n", debugtable[(int)(tok->specval) - debugtableoffset], tok->specval);
-    printf("intval: %x\n", tok->intval);
-    printf("realval: %lx\n", dbu.output);
-    printf("strval: %s\n", tok->strval);
-    printf("entry: %p\n", tok->entry);
-    printf("type_sym: %p\n", tok->type_sym);
-    printf("leaf: %p\n", tok->leaf);
-    printf("next: %p\n", tok->next);
+    printf("%12s%x\n", "Type: ", tok->type);
+    printf("%12s%s(%d)\n", "specval: ", debugtable[(int)(tok->specval) - debugtableoffset], tok->specval);
+    printf("%12s%x\n", "intval: ", tok->intval);
+    printf("%12s%lx\n", "realval: ", dbu.output);
+    printf("%12s%s\n", "strval: ", tok->strval);
+    printf("%12s%p\n", "entry: ", tok->entry);
+    printf("%12s%p\n", "type_sym: ", tok->type_sym);
+    printf("%12s%p\n", "leaf: ", tok->leaf);
+    printf("%12s%p\n", "next: ", tok->next);
   }
-    printf("-----END DEBUG TOKEN-----\n");
+    printf("------END DEBUG TOKEN------\n");
 }
 
 void token_append(token tok1, token tok2){

--- a/src/token.c
+++ b/src/token.c
@@ -24,29 +24,28 @@ token talloc(){
 }
 
 token cleartok(token t){
-  t->type = TYPE_CLEAR;
-  t->specval = -1;
-  t->intval = 0;
-  t->realval = 0.0;
-  t->strval = NULL;
-  t->next = NULL;
-  t->leaf = NULL;
+  memset(t, 0, sizeof(struct tokenstruct));
+  t->specval = -1; //tokentype of 0 is YYEOF
   return t;
 }
 
 token inittok(toktype type, int specval, int intval, double realval, char* strval){
-  token t = malloc(sizeof(struct tokenstruct));
+  token t = talloc();
   t->type = type;
   t->specval = specval;
   t->intval = intval;
   t->realval = realval;
   size_t strsize = strlen(strval);
-  //TODO: Take care of mem leaks from this malloc
   t->strval = malloc(strsize * sizeof(char));
   strncpy(t->strval, strval, strsize);
-  t->next = NULL;
-  t->leaf = NULL;
   return t;
+}
+
+void tfree(token t){
+  if(t->strval){
+    free(t->strval);
+  }
+  free(t);
 }
 
 void debugtokentree(token tok){

--- a/src/token.h
+++ b/src/token.h
@@ -50,6 +50,7 @@ typedef struct tokenstruct* token;
 token talloc();
 token cleartok(token t);
 token inittok(toktype type, int specval, int intval, double realval, char* strval);
+void tfree(token t);
 void debugtoken(token tok);
 void debugtokentree(token tok);
 void tokentest(token tok);


### PR DESCRIPTION
Add method to free tokens specifically. Copy strings instead of passing pointers. Free label and constant tokens after parsing.